### PR TITLE
Error compiling on g++ and -Wall flags

### DIFF
--- a/Delegate.h
+++ b/Delegate.h
@@ -651,7 +651,7 @@ public:
 		return right.IsLess(*this);
 	}
 	DelegateMemento (const DelegateMemento &right)	:
-		m_pFunction(right.m_pFunction), m_pthis(right.m_pthis)
+		m_pthis(right.m_pthis), m_pFunction(right.m_pFunction)
 #if !defined(FASTDELEGATE_USESTATICFUNCTIONHACK)
 		, m_pStaticFunction (right.m_pStaticFunction)
 #endif


### PR DESCRIPTION
Fixed an error when compiling with g++ and -Wall flags.
m_pthis should init first than m_pFunction
