### PR TITLE
Implemented a Clear method to remove all delegates from a signal

### DIFF
--- a/Signal.h
+++ b/Signal.h
@@ -60,7 +60,12 @@ public:
 	{
 		delegateList.erase( MakeDelegate( obj, func ) );
 	}
-
+	
+	void Clear( )
+        {
+            delegateList.clear();
+        }
+        
 	void Emit() const
 	{
 		for (DelegateIterator i = delegateList.begin(); i != delegateList.end(); ++i)
@@ -129,7 +134,10 @@ public:
 			(*i)( p1 );
 		}
 	}
-
+	void Clear( )
+        {
+            delegateList.clear();
+        }
 	void operator() ( Param1 p1 ) const
 	{
 		Emit( p1 );
@@ -190,7 +198,12 @@ public:
 			(*i)( p1, p2 );
 		}
 	}
-
+	
+	void Clear( )
+        {
+            delegateList.clear();
+        }
+        
 	void operator() ( Param1 p1, Param2 p2 ) const
 	{
 		Emit( p1, p2 );
@@ -256,6 +269,11 @@ public:
 	{
 		Emit( p1, p2, p3 );
 	}
+
+	void Clear( )
+        {
+            delegateList.clear();
+        }
 };
 
 
@@ -317,6 +335,10 @@ public:
 	{
 		Emit( p1, p2, p3, p4 );
 	}
+	void Clear( )
+        {
+            delegateList.clear();
+        }
 };
 
 
@@ -378,6 +400,10 @@ public:
 	{
 		Emit( p1, p2, p3, p4, p5 );
 	}
+	void Clear( )
+        {
+            delegateList.clear();
+        }
 };
 
 
@@ -439,6 +465,10 @@ public:
 	{
 		Emit( p1, p2, p3, p4, p5, p6 );
 	}
+	void Clear( )
+        {
+            delegateList.clear();
+        }
 };
 
 
@@ -500,6 +530,10 @@ public:
 	{
 		Emit( p1, p2, p3, p4, p5, p6, p7 );
 	}
+	void Clear( )
+        {
+            delegateList.clear();
+        }
 };
 
 
@@ -561,6 +595,10 @@ public:
 	{
 		Emit( p1, p2, p3, p4, p5, p6, p7, p8 );
 	}
+	void Clear( )
+        {
+            delegateList.clear();
+        }
 };
 
 


### PR DESCRIPTION
Hi there,

I've found some cases where you have a lot of transient "listener" objects and some non transient providers, so a clear method would be useful when you don't wan't to bother unregistering all of them one by one.

I would like to implement a Disconnect method that receives only the object and removes all delegates attached to them, but found that the pointer to the object is stored on the closure and could not retrieve it easily. Do you know a better way to do this?

Cy'a
