### PR TITLE
Support for disconnecting a signal while its Emit() is in progress

### DIFF
--- a/Signal.h
+++ b/Signal.h
@@ -68,9 +68,9 @@ public:
 
 	void Emit() const
 	{
-		for (DelegateIterator i = delegateList.begin(); i != delegateList.end(); ++i)
+		for (DelegateIterator i = delegateList.begin(); i != delegateList.end(); )
 		{
-			(*i)();
+			(*(i++))();
 		}
 	}
 
@@ -134,9 +134,9 @@ public:
 
 	void Emit( Param1 p1 ) const
 	{
-		for (DelegateIterator i = delegateList.begin(); i != delegateList.end(); ++i)
+		for (DelegateIterator i = delegateList.begin(); i != delegateList.end(); )
 		{
-			(*i)( p1 );
+			(*(i++))( p1 );
 		}
 	}
 
@@ -200,9 +200,9 @@ public:
 
 	void Emit( Param1 p1, Param2 p2 ) const
 	{
-		for (DelegateIterator i = delegateList.begin(); i != delegateList.end(); ++i)
+		for (DelegateIterator i = delegateList.begin(); i != delegateList.end(); )
 		{
-			(*i)( p1, p2 );
+			(*(i++))( p1, p2 );
 		}
 	}
 
@@ -266,9 +266,9 @@ public:
 
 	void Emit( Param1 p1, Param2 p2, Param3 p3 ) const
 	{
-		for (DelegateIterator i = delegateList.begin(); i != delegateList.end(); ++i)
+		for (DelegateIterator i = delegateList.begin(); i != delegateList.end(); )
 		{
-			(*i)( p1, p2, p3 );
+			(*(i++))( p1, p2, p3 );
 		}
 	}
 
@@ -332,9 +332,9 @@ public:
 
 	void Emit( Param1 p1, Param2 p2, Param3 p3, Param4 p4 ) const
 	{
-		for (DelegateIterator i = delegateList.begin(); i != delegateList.end(); ++i)
+		for (DelegateIterator i = delegateList.begin(); i != delegateList.end(); )
 		{
-			(*i)( p1, p2, p3, p4 );
+			(*(i++))( p1, p2, p3, p4 );
 		}
 	}
 
@@ -398,9 +398,9 @@ public:
 
 	void Emit( Param1 p1, Param2 p2, Param3 p3, Param4 p4, Param5 p5 ) const
 	{
-		for (DelegateIterator i = delegateList.begin(); i != delegateList.end(); ++i)
+		for (DelegateIterator i = delegateList.begin(); i != delegateList.end(); )
 		{
-			(*i)( p1, p2, p3, p4, p5 );
+			(*(i++))( p1, p2, p3, p4, p5 );
 		}
 	}
 
@@ -464,9 +464,9 @@ public:
 
 	void Emit( Param1 p1, Param2 p2, Param3 p3, Param4 p4, Param5 p5, Param6 p6 ) const
 	{
-		for (DelegateIterator i = delegateList.begin(); i != delegateList.end(); ++i)
+		for (DelegateIterator i = delegateList.begin(); i != delegateList.end(); )
 		{
-			(*i)( p1, p2, p3, p4, p5, p6 );
+			(*(i++))( p1, p2, p3, p4, p5, p6 );
 		}
 	}
 
@@ -530,9 +530,9 @@ public:
 
 	void Emit( Param1 p1, Param2 p2, Param3 p3, Param4 p4, Param5 p5, Param6 p6, Param7 p7 ) const
 	{
-		for (DelegateIterator i = delegateList.begin(); i != delegateList.end(); ++i)
+		for (DelegateIterator i = delegateList.begin(); i != delegateList.end(); )
 		{
-			(*i)( p1, p2, p3, p4, p5, p6, p7 );
+			(*(i++))( p1, p2, p3, p4, p5, p6, p7 );
 		}
 	}
 
@@ -596,9 +596,9 @@ public:
 
 	void Emit( Param1 p1, Param2 p2, Param3 p3, Param4 p4, Param5 p5, Param6 p6, Param7 p7, Param8 p8 ) const
 	{
-		for (DelegateIterator i = delegateList.begin(); i != delegateList.end(); ++i)
+		for (DelegateIterator i = delegateList.begin(); i != delegateList.end(); )
 		{
-			(*i)( p1, p2, p3, p4, p5, p6, p7, p8 );
+			(*(i++))( p1, p2, p3, p4, p5, p6, p7, p8 );
 		}
 	}
 


### PR DESCRIPTION
Calling Disconnect() on an emitted signal causes crash because the iterator of delegateList becomes invalid after erasing element from std::set. I have changed the code and now the iterator remains valid.

Test code below:

``` c++
#include <stdio.h>
#include "Signal.h"
using namespace Gallant;

class Foo
{
public:
    Signal0< void > signal;

    void Action1( void )
    {
        signal.Connect(this, &Foo::Slot1);
        signal();
    }

    void Slot1( void )
    {
        printf("Foo::slot1\n");
    }

    void Action2( void )
    {
        signal.Connect(this, &Foo::Slot2);
        signal();
    }

    void Slot2( void )
    {
        printf("Foo::slot2\n");
        signal.Disconnect(this, &Foo::Slot2); // crash here
    }
};

int main()
{
    Foo foo;

    foo.Action1(); // Slot 1 is connected and emitted, ok
    foo.signal.Clear();
    printf("test 1 passed\n");

    foo.Action2(); // Slot 2 is connected and emitted, crash
    printf("test 2 passed\n");

    return 0;
}
```
